### PR TITLE
Fix TP/KK melee modifier caculations; update WdS handout URL; etc.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nix-filter.url = "github:numtide/nix-filter";
     wds-handouts = {
       url =
-        "https://dsa-satinavsketten.de/fileadmin/downloads/offiziell/Regelmaterial&Errata/WdS-Handouts.pdf";
+        "https://dsa-satinavsketten.de/fileadmin/downloads/offiziell/Regelmaterial%26Errata/WdS-Handouts.pdf";
       flake = false;
     };
     fanpaket = {

--- a/src/common.lua
+++ b/src/common.lua
@@ -426,6 +426,16 @@ function common.proviant_vermoegen()
   common.inner_rows(content, 4)
 end
 
+-- Truncating integer division
+function common.div_trunc(numerator, denominator)
+  local quotient = numerator // denominator
+  if quotient < 0 and numerator % denominator ~= 0 then
+    quotient = quotient + 1
+  end
+  return quotient
+end
+
+
 common.schaden = {}
 
 function common.schaden.parse(input)
@@ -501,14 +511,7 @@ function common.schaden.mod(tp, schwelle, schritt)
     return nil
   end
   if schwelle ~= nil and schritt ~= nil and schritt > 0 then
-    while cur_kk < schwelle do
-      tp.num = tp.num - 1
-      cur_kk = cur_kk + schritt
-    end
-    while cur_kk >= schwelle + schritt do
-      tp.num = tp.num + 1
-      cur_kk = cur_kk - schritt
-    end
+    tp.num = tp.num + common.div_trunc(cur_kk - schwelle, schritt)
   end
   return tp
 end

--- a/src/frontseite.tex
+++ b/src/frontseite.tex
@@ -80,7 +80,7 @@
 \begin{dsaSheetBox}[2\fboxsep + 6.72cm]
     \setlength{\tabcolsep}{0pt}
     \renewcommand{\arraystretch}{1.325}
-    \begin{NiceTabular}{p{3.1cm}|x{1.2cm}|x{1.2cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}}
+    \begin{NiceTabular}[color-inside]{p{3.1cm}|x{1.2cm}|x{1.2cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}}
         \setarstrut{\tiny} & \dsaSH Modifikator & \dsaSH Start & \dsaSH Aktuell \\ \restorearstrut
         \directlua{
             frontseite.eigenschaften:links()
@@ -91,7 +91,7 @@
     \setlength{\tabcolsep}{0pt}
     \renewcommand{\arraystretch}{1.325}
     \vspace{-0.375pt}
-    \begin{NiceTabular}{p{5.3cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}|x{1.2cm}@{/}x{0.8cm}|x{1.2cm}}
+    \begin{NiceTabular}[color-inside]{p{5.3cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}!{\vrule width 4\arrayrulewidth}x{1.2cm}|x{1.2cm}@{/}x{0.8cm}|x{1.2cm}}
         \setarstrut{\tiny} & \dsaSH Aktuell & \dsaSH Modifikator & \multicolumn{2}{l}{
             \dsaSH \begin{tabular}{x{1.25cm}@{\tiny/}x{0.85cm}}
                 Zugekauft & Max

--- a/src/kampfbogen.lua
+++ b/src/kampfbogen.lua
@@ -34,10 +34,7 @@ local function atpa_mod(basis, talent, schwelle, schritt, wm, art, spez)
   local val = basis
   local cur_kk = data:cur("KK")
   if cur_kk ~= "" and schwelle ~= nil and schritt ~= nil and schritt > 0 then
-    while cur_kk < schwelle do
-      val = val - 1
-      cur_kk = cur_kk + schritt
-    end
+    val = val + common.div_trunc(cur_kk - schwelle, schritt)
   end
   if art ~= nil and spez ~= nil then
     for _, s in ipairs(spez) do
@@ -151,8 +148,7 @@ nahkampf_render[3]= {false, function(v, talent, ebe)
   end
 end}
 nahkampf_render[5]= {true, function(v)
-  local tp = common.schaden.parse(v)
-  common.schaden.render(tp)
+  common.schaden.render(common.schaden.parse(v))
 end}
 for i=8,10 do
   nahkampf_render[i] = {true, common.render_delta}

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -657,7 +657,7 @@ function schema.Notizen.example(printer)
 end
 
 local Tier = d.Row:def({name = "Tier", description = "Werte eines Tiers."},
-  {"Name", String}, {"Art", String, ""}, {"INI", OptNum, {}}, {"AT", OptNum, {}}, {"PA", OptNum, {}}, {"TP", Schaden, ""}, {"LE", OptNum, {}}, {"RS", OptNum, {}}, {"KO", OptNum, {}}, {"KO", OptNum, {}}, {"GS", OptNum, {}}, {"AU", OptNum, {}}, {"MR", OptNum, {}}, {"LO", OptNum, {}}, {"TK", OptNum, {}}, {"ZK", OptNum, {}})
+  {"Name", String}, {"Art", String, ""}, {"INI", OptNum, {}}, {"AT", OptNum, {}}, {"PA", OptNum, {}}, {"TP", Schaden, ""}, {"LE", OptNum, {}}, {"RS", OptNum, {}}, {"KO", OptNum, {}}, {"GS", OptNum, {}}, {"AU", OptNum, {}}, {"MR", OptNum, {}}, {"LO", OptNum, {}}, {"TK", OptNum, {}}, {"ZK", OptNum, {}})
 d:singleton(d.List, {name = "Tiere", description = "Liste von Tieren."}, {Tier})
 function schema.Tiere.example(printer)
 


### PR DESCRIPTION
TP/KK modifiers for melee weapon damage, AT, and PA are currently incorrectly rounded towards negative infinity instead of zero as required by the rule book. This PR fixes the issue and couple of others (see commit messages).