### PR TITLE
Fix and simplify TP/KK melee modifier caculations (attempt 2)

### DIFF
--- a/src/common.lua
+++ b/src/common.lua
@@ -426,6 +426,16 @@ function common.proviant_vermoegen()
   common.inner_rows(content, 4)
 end
 
+-- Truncating integer division
+function common.div_trunc(numerator, denominator)
+  local quotient = numerator // denominator
+  if quotient < 0 and numerator % denominator ~= 0 then
+    quotient = quotient + 1
+  end
+  return quotient
+end
+
+
 common.schaden = {}
 
 function common.schaden.parse(input)
@@ -501,14 +511,7 @@ function common.schaden.mod(tp, schwelle, schritt)
     return nil
   end
   if schwelle ~= nil and schritt ~= nil and schritt > 0 then
-    while cur_kk < schwelle do
-      tp.num = tp.num - 1
-      cur_kk = cur_kk + schritt
-    end
-    while cur_kk >= schwelle + schritt do
-      tp.num = tp.num + 1
-      cur_kk = cur_kk - schritt
-    end
+    tp.num = tp.num + common.div_trunc(cur_kk - schwelle, schritt)
   end
   return tp
 end

--- a/src/kampfbogen.lua
+++ b/src/kampfbogen.lua
@@ -34,10 +34,7 @@ local function atpa_mod(basis, talent, schwelle, schritt, wm, art, spez)
   local val = basis
   local cur_kk = data:cur("KK")
   if cur_kk ~= "" and schwelle ~= nil and schritt ~= nil and schritt > 0 then
-    while cur_kk < schwelle do
-      val = val - 1
-      cur_kk = cur_kk + schritt
-    end
+    val = val + common.div_trunc(cur_kk - schwelle, schritt)
   end
   if art ~= nil and spez ~= nil then
     for _, s in ipairs(spez) do
@@ -151,8 +148,7 @@ nahkampf_render[3]= {false, function(v, talent, ebe)
   end
 end}
 nahkampf_render[5]= {true, function(v)
-  local tp = common.schaden.parse(v)
-  common.schaden.render(tp)
+  common.schaden.render(common.schaden.parse(v))
 end}
 for i=8,10 do
   nahkampf_render[i] = {true, common.render_delta}


### PR DESCRIPTION
TP/KK modifiers for melee weapon damage, AT, and PA were incorrectly rounded towards negative infinity instead of zero as required by the rule book.

The modifier calculation is now done using integer division rather than repeated addition/subtraction.