### PR TITLE
Use the JPEG2000-encoded wallpaper image from the WdS handout as is

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,8 +126,8 @@
                 cp ${copse} "$out/share/fonts/Copse-Regular.ttf"
                 cp ${mason} "$out/share/fonts/Mason-Bold.ttf"
                 cp "${fanpaket}/DSA_Fanpaket_PNG/Fan-Produkt-Logo.png" "$out/share/img/logo-fanprodukt.png"
-                ${poppler_utils}/bin/pdfimages -f 2 -l 2 "${wds-handouts}" wds
-                ${imagemagick}/bin/convert wds-000.ppm "$out/share/img/wallpaper.jpg"
+                ${poppler_utils}/bin/pdfimages -jp2 -f 2 -l 2 "${wds-handouts}" wds
+                mv wds-000.jp2 "$out/share/img/wallpaper.jp2"
                 cp import.xsl heldensoftware-meta.xml "$out/share"
 
                 printenv GENERATOR >$out/bin/dsa41held

--- a/src/data.lua
+++ b/src/data.lua
@@ -12,4 +12,4 @@ if i < #arg then
   tex.error("zu viele Argumente. Erstes überflüssiges Argument: '" .. tostring(arg[i+1]) .. "'")
 end
 
-return loadfile("values.lua", "t")(arg[i])
+return assert(loadfile("values.lua", "t"))(arg[i])

--- a/src/dsa.cls
+++ b/src/dsa.cls
@@ -110,20 +110,26 @@
 % environments
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\newlength\dsaOldParindent
+\renewcommand{\ThisCenterWallPaper}[3][]{%
+  \AddToShipoutPicture*{\put(\LenToUnit{\wpXoffset},\LenToUnit{\wpYoffset}){%
+    \parbox[b][\paperheight]{\paperwidth}{%
+      \vfill
+      \centering
+      \includegraphics[width=#2\paperwidth,height=#2\paperheight,keepaspectratio,#1]{#3}%
+      \vfill
+  }}}
+}
+
 \newenvironment{dsaCharacterSheet}{
   \pagebreak
-  \setlength{\dsaOldParindent}{\parindent}
   \setlength{\parindent}{0pt}
   \ifbgwallpaper
     \ClearWallPaper
     \setlength{\wpXoffset}{-0.3cm}%
     \setlength{\wpYoffset}{-0.1cm}%
-    \ThisCenterWallPaper{1.0275}{img/wallpaper.jpg}%
+    \ThisCenterWallPaper[decodearray={1 0 }]{1.0275}{img/wallpaper.jp2}%
   \fi
-}{
-  \setlength{\parindent}{\dsaOldParindent}
-}
+}{}
 
 % Set default value for border spacing within character sheet boxes
 \setlength{\fboxsep}{3mm}

--- a/src/dsa.cls
+++ b/src/dsa.cls
@@ -79,6 +79,9 @@
 \usepackage{calc}
 \usetikzlibrary{positioning,fit,calc,backgrounds}
 
+\DeclareGraphicsRule{.jp2}{jpg}{.jp2}{}
+\DeclareGraphicsExtensions{.pdf,.png,.jbig2,.jb2,.jp2,.jpg,.jpeg,.mps}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % font selection
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/frontseite.tex
+++ b/src/frontseite.tex
@@ -112,7 +112,7 @@
 \end{dsaSheetBox}%
 \begin{tikzpicture}[remember picture, overlay]
     \node[inner sep=0pt] at ([xshift=0cm,yshift=-1.35cm]current page.north) {%
-        \includegraphics[width=6cm]{img/logo-fanprodukt.png}%
+        \includegraphics[width=6cm]{img/logo-fanprodukt}%
     };%
 \end{tikzpicture}%
 

--- a/src/tools.lua
+++ b/src/tools.lua
@@ -33,7 +33,7 @@ elseif arg[curarg] ~= nil then
 end
 
 local d = require("schemadef")
-local schema = loadfile("schema.lua", "t")(true)
+local schema = assert(loadfile("schema.lua", "t"))(true)
 
 if gendoc then
   if standalone then
@@ -94,7 +94,7 @@ end
 if validate then
   local res = 0
   local prev_pcount = 0
-  local values = loadfile("values.lua")
+  local values = assert(loadfile("values.lua", "t"))
   for i = curarg + 1,#arg do
     values(arg[i])
   end

--- a/src/values.lua
+++ b/src/values.lua
@@ -1,5 +1,5 @@
 local d = require("schemadef")
-local schema = loadfile("schema.lua", "t")(false)
+local schema = assert(loadfile("schema.lua", "t"))(false)
 local skt = require("skt")
 
 local input = ...

--- a/src/vertrautendokument.tex
+++ b/src/vertrautendokument.tex
@@ -9,7 +9,7 @@
       \portraitwp{}
 
       \begin{center}
-         \includegraphics[width=6cm]{img/logo-fanprodukt.png}
+         \includegraphics[width=6cm]{img/logo-fanprodukt}
       \end{center}
 
       \setlength{\multicolsep}{11pt}


### PR DESCRIPTION
The installation script downloads a suitably licensed official PDF handout, extracts its wallpaper image for later use in Heldendokument. Currently, this wallpaper is transcoded to JPEG which is both lossy and results in a larger file size than the original.

This pull request modifies the installation process:

 1. Invoke `pdimages` such that it extracts the exact bitstream of the wallpaper images. Move the resulting JPEG2000 file to `wallpaper.jp2`.
 2. Tell LuaTeX how to handle images with the `.jp2` file extension.
 3. Tell LuaTeX the new wallpaper image file name.

Caveat: The wallpaper bitstream contains the image with inverted greyscale colours. Suitable PDF commands then invert the colours back to the expected result and, luckily, the `graphicx` module provides an undocumented option `\includegraphics[decodearray=…]{…}` to do just that. Unfortunately, not all PDF viewers support this PDF feature and Blink (Chrome, Edge, etc.) is among them. I successfully tested them in Adobe Reader, Firefox, Okular, Evince, and QPdfviewer. As a workaround, one may open the PDF using a compatible viewer and “print” it to a new PDF file or pass it through Ghostscript with `-dCompatibilityLevel=1.4` (which will decode and colour-transform the wallpaper image and store it in a lossless format inside the resulting PDF).

Other minor change(s):
 * Don’t include the file extension when specifying the path to the logo on the front page header (currently `logo-fanprodukt.png`). This makes it trivial to replace the image with something in a different format (JPEG, EPS, etc.) in case anybody wants to do that.